### PR TITLE
Add TestResultSummary model and update references

### DIFF
--- a/src/athena/models/test_result_summary.py
+++ b/src/athena/models/test_result_summary.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from athena.models.test_config import TestConfig
+from athena.models.test_result import TestResult
+
+class TestResultSummary(BaseModel):
+    test_config: TestConfig
+    test_result: TestResult

--- a/src/athena/models/test_suite_summary.py
+++ b/src/athena/models/test_suite_summary.py
@@ -4,9 +4,9 @@ from typing import List
 from pydantic import Field
 
 from athena.models import BaseModel
-from athena.models.test_result import TestResult
+from athena.models.test_result_summary import TestResultSummary
 
 
 class TestSuiteSummary(BaseModel):
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
-    results: List[TestResult]
+    results: List[TestResultSummary]

--- a/src/athena/services/test_service.py
+++ b/src/athena/services/test_service.py
@@ -2,7 +2,7 @@ from typing import List
 
 from athena.models.athena_test_suite_config import AthenaTestSuiteConfig
 from athena.models.test_config import TestConfig
-from athena.models.test_result import TestResult
+from athena.models.test_result_summary import TestResultSummary
 from athena.protocols.test_plugins_manager_protocol import TestPluginsManagerProtocol
 from athena.services.configuration_service import ConfigurationService
 
@@ -18,7 +18,7 @@ class TestService:
         self.plugin_manager = plugin_manager
         self.config_manager = config_manager
 
-    def run_tests(self, config: AthenaTestSuiteConfig) -> List[TestResult]:
+    def run_tests(self, config: AthenaTestSuiteConfig) -> List[TestResultSummary]:
         """Execute tests based on the configuration."""
         results = []
 
@@ -35,7 +35,8 @@ class TestService:
                 parameters=merged_params,
             )
 
-            result = self.plugin_manager.run_test(test_config_copy)
-            results.append(result)
+            test_result = self.plugin_manager.run_test(test_config_copy)
+            result_summary = TestResultSummary(test_config=test_config_copy, test_result=test_result)
+            results.append(result_summary)
 
         return results

--- a/src/athena/services/test_suite_service.py
+++ b/src/athena/services/test_suite_service.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from athena.models.test_suite_summary import TestSuiteSummary
+from athena.models.test_result_summary import TestResultSummary
 from athena.protocols.data_parser_plugins_manager_protocol import (
     DataParserPluginsManagerProtocol,
 )
@@ -46,7 +47,12 @@ class TestSuiteService:
         test_manager = TestService(self.test_plugins_manager, self.config_manager)
         results = test_manager.run_tests(config)
 
-        report_manager = ReportService(self.report_plugins_manager)
-        report_manager.generate_reports(config, results)
+        test_result_summaries = [
+            TestResultSummary(test_config=result.test_config, test_result=result.test_result)
+            for result in results
+        ]
 
-        return TestSuiteSummary(results=results)
+        report_manager = ReportService(self.report_plugins_manager)
+        report_manager.generate_reports(config, test_result_summaries)
+
+        return TestSuiteSummary(results=test_result_summaries)


### PR DESCRIPTION
Add a new `TestResultSummary` model and update related services to use it.

* **Add `TestResultSummary` model**
  - Create `src/athena/models/test_result_summary.py` with `TestConfig` and `TestResult` fields.
  - Use `pydantic` for model validation.

* **Update `TestSuiteSummary` model**
  - Replace `results: List[TestResult]` with `results: List[TestResultSummary>` in `src/athena/models/test_suite_summary.py`.

* **Update `TestSuiteService`**
  - Modify `run_tests_from_config` method to create and return `TestResultSummary` objects instead of `TestResult`.
  - Update `run_tests_from_config` to pass `TestResultSummary` objects to `ReportService`.

* **Update `TestService`**
  - Change `run_tests` method to return `List[TestResultSummary]` instead of `List[TestResult]`.
  - Modify `run_tests` to create `TestResultSummary` objects.

